### PR TITLE
Add docking node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This repository contains the following demos:
 * [Fiducial Follow](fiducial_follow) 
 * [move_demo](move_demo) 
 * [Partybot](partybot) (work in progress)
+* [Docking](docking)
 

--- a/docking/CMakeLists.txt
+++ b/docking/CMakeLists.txt
@@ -21,10 +21,10 @@ find_package(catkin REQUIRED COMPONENTS rospy move_base_msgs
 #)
 
 ## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-)
+#generate_messages(
+# DEPENDENCIES
+#  std_msgs
+#)
 
 ###################################
 ## catkin specific configuration ##

--- a/docking/CMakeLists.txt
+++ b/docking/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(docking)
+
+## Find catkin macros and libraries
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS rospy move_base_msgs
+             message_generation std_msgs)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## Generate services in the 'srv' folder
+#add_service_files(
+#  FILES
+#  Dock.srv
+#)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS
+  LIBRARIES
+  CATKIN_DEPENDS fiducials move_basic
+)
+
+
+###########
+## Build ##
+###########
+
+#############
+## Install ##
+#############
+
+
+#############
+## Testing ##
+#############
+

--- a/docking/CMakeLists.txt
+++ b/docking/CMakeLists.txt
@@ -15,16 +15,16 @@ find_package(catkin REQUIRED COMPONENTS rospy move_base_msgs
 ################################################
 
 ## Generate services in the 'srv' folder
-#add_service_files(
-#  FILES
-#  Dock.srv
-#)
+add_service_files(
+  FILES
+  Dock.srv
+)
 
 ## Generate added messages and services with any dependencies listed here
-#generate_messages(
-# DEPENDENCIES
-#  std_msgs
-#)
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/docking/README.md
+++ b/docking/README.md
@@ -1,0 +1,30 @@
+
+
+# Nodes
+
+## docking.py
+
+The docking service uses [fiducials](http://wiki.ros.org/fiducials)
+to detect fiducials markers in an image feed from a camera. When the sevice
+ is invoked, the robot rotates to find a fiducial in order to determine is
+ location and Then navigates to a designated point along a specified path.
+
+### Services Provided
+
+`/dock` (`std_srvs/Empty`): invokes the docking service
+
+
+### Publications
+
+`/move_base/goal` (`move_base_msgs/MoveBaseActionGoal`): sends a movement goal
+
+### Parameters
+
+`path` a string containg a list of poses in the form (x, y, theta), where
+ x and y are distances in meters and theta is an angle in degrees, relative
+ to the map frame.
+
+### Example usage
+
+    rosrun docking docking.py
+

--- a/docking/README.md
+++ b/docking/README.md
@@ -22,7 +22,7 @@ to detect fiducials markers in an image feed from a camera. When the sevice
 
 `~waypoints` a string containg a list of poses in the form `x0 y0 theta, x1 y1 theta1`, where
  x and y are distances in meters and theta is an angle in degrees, relative
- to the map frame.
+ to the map frame. Default: "-1 0 0, 0 0 0"
 
 `~angle_increment`: Angle to rotate in degrees if object is not found. Default `40`.
 

--- a/docking/README.md
+++ b/docking/README.md
@@ -11,7 +11,7 @@ to detect fiducials markers in an image feed from a camera. When the sevice
 
 ### Services Provided
 
-`/dock` (`std_srvs/Empty`): invokes the docking service
+`/dock` (`std_srvs/Trigger`): invokes the docking service
 
 
 ### Publications
@@ -20,11 +20,19 @@ to detect fiducials markers in an image feed from a camera. When the sevice
 
 ### Parameters
 
-`path` a string containg a list of poses in the form (x, y, theta), where
+`~waypoints` a string containg a list of poses in the form `x0 y0 theta, x1 y1 theta1`, where
  x and y are distances in meters and theta is an angle in degrees, relative
  to the map frame.
 
+`~angle_increment`: Angle to rotate in degrees if object is not found. Default `40`.
+
+`~rotation_limit`: How many times to rotate `angle_increment` radians if the object is not found,
+ before giving up. Default `8`.
+
+
+
 ### Example usage
 
-    rosrun docking docking.py
+    roslaunch docking docking.launch
 
+    rosservice call /dock

--- a/docking/README.md
+++ b/docking/README.md
@@ -7,11 +7,12 @@
 The docking service uses [fiducials](http://wiki.ros.org/fiducials)
 to detect fiducials markers in an image feed from a camera. When the sevice
  is invoked, the robot rotates to find a fiducial in order to determine is
- location and Then navigates to a designated point along a specified path.
+ location and Then navigates to a set of waypoints in sequence.
 
 ### Services Provided
 
-`/dock` (`std_srvs/Trigger`): invokes the docking service
+`/dock` (`docking/Dock`): invokes the docking service
+The robot will rotate until it either sees the target fiducial or completes one revolution. If a fiducial is seen, it will attempt to navigate to the waypoints in sequence. The format of a waypoint is three elements representing x, y, and theta. x and y are co-ordinates relative to the fiducial in meters and theta is a heading angle in degrees. The strings XandYare replaced by the currentxandy` co-ordinates, respectively.
 
 
 ### Publications
@@ -19,10 +20,6 @@ to detect fiducials markers in an image feed from a camera. When the sevice
 `/move_base/goal` (`move_base_msgs/MoveBaseActionGoal`): sends a movement goal
 
 ### Parameters
-
-`~waypoints` a string containg a list of poses in the form `x0 y0 theta, x1 y1 theta1`, where
- x and y are distances in meters and theta is an angle in degrees, relative
- to the map frame. Default: "-1 0 0, 0 0 0"
 
 `~angle_increment`: Angle to rotate in degrees if object is not found. Default `40`.
 
@@ -35,4 +32,4 @@ to detect fiducials markers in an image feed from a camera. When the sevice
 
     roslaunch docking docking.launch
 
-    rosservice call /dock
+    rosservice call /dock "{'fiducial_id': 42, 'waypoints': '-1 Y 0, -1 0 0'}"

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -2,6 +2,8 @@
     <include file="$(find magni_nav)/launch/aruco.launch"/>
     <include file="$(find magni_nav)/launch/move_basic.launch"/>
 
+    <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar">
+
     <node pkg="docking" type="dock.py" name="docking">
        <param name="waypoints" value="0 1 0, 0 0 0"/>
     </node>

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -1,0 +1,9 @@
+<launch>
+    <include file="$(find magni_nav)/launch/aruco.launch"/>
+    <include file="$(find magni_nav)/launch/move_basic.launch"/>
+
+    <node pkg="docking" type="docking.py" name="docking">
+       <param name="waypoints" value="0 1 0, 0 0 0"/>
+    </node>
+</launch>
+

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -5,8 +5,7 @@
 
     <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar"/>
 
-    <node pkg="docking" type="dock.py" name="docking">
-       <param name="waypoints" value="-1.5 -0.2 0, -1 0 0, 0 0 0"/>
+    <node pkg="docking" type="dock.py" name="docking" output="screen">
     </node>
 </launch>
 

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -5,7 +5,7 @@
     <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar">
 
     <node pkg="docking" type="dock.py" name="docking">
-       <param name="waypoints" value="0 1 0, 0 0 0"/>
+       <param name="waypoints" value="-1.5 -0.2 0, -1 0 0, 0 0 0""/>
     </node>
 </launch>
 

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -1,6 +1,7 @@
 <launch>
     <include file="$(find magni_nav)/launch/aruco.launch"/>
     <include file="$(find magni_nav)/launch/move_basic.launch"/>
+    <include file="$(find magni_description)/launch/description.launch"/>
 
     <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar"/>
 

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -2,7 +2,7 @@
     <include file="$(find magni_nav)/launch/aruco.launch"/>
     <include file="$(find magni_nav)/launch/move_basic.launch"/>
 
-    <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar">
+    <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar"/>
 
     <node pkg="docking" type="dock.py" name="docking">
        <param name="waypoints" value="-1.5 -0.2 0, -1 0 0, 0 0 0"/>

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -5,7 +5,7 @@
     <node pkg="pi_sonar" type="pi_sonar" name="pi_sonar">
 
     <node pkg="docking" type="dock.py" name="docking">
-       <param name="waypoints" value="-1.5 -0.2 0, -1 0 0, 0 0 0""/>
+       <param name="waypoints" value="-1.5 -0.2 0, -1 0 0, 0 0 0"/>
     </node>
 </launch>
 

--- a/docking/launch/docking.launch
+++ b/docking/launch/docking.launch
@@ -2,7 +2,7 @@
     <include file="$(find magni_nav)/launch/aruco.launch"/>
     <include file="$(find magni_nav)/launch/move_basic.launch"/>
 
-    <node pkg="docking" type="docking.py" name="docking">
+    <node pkg="docking" type="dock.py" name="docking">
        <param name="waypoints" value="0 1 0, 0 0 0"/>
     </node>
 </launch>

--- a/docking/nodes/dock.py
+++ b/docking/nodes/dock.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python
+
+"""
+Copyright (c) 2019, Ubiquity Robotics
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of fiducial_follow nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+"""
+Rotate to find a fiducial, and then navigate to a series of points
+
+It provides a service /rotate, which can be called from the command line:
+
+$ rosservice call /dock
+
+"""
+
+import rospy
+import actionlib
+from actionlib_msgs.msg import *
+from std_srvs.srv import Trigger, TriggerResponse
+from geometry_msgs.msg import Quaternion, Point, PoseStamped, Pose
+from fiducial_msgs.msg import FiducialArray
+import move_base_msgs.msg
+import tf.transformations
+import tf2_ros
+import tf2_geometry_msgs
+import math
+import traceback
+from geometry_msgs.msg import Quaternion, Point
+import time
+
+# Utility function to convert radians to degrees
+def degrees(r):
+    return 180.0 * r / math.pi
+
+def radians(d):
+    return d * math.pi / 180.0
+
+
+# Class to encapsulate our node
+class Dock:
+    """
+    Constructor for our class
+    """
+    def __init__(self):
+        self.ok = False
+        rospy.init_node("dock")
+
+        # Set up transform buffer and listener
+        self.tf_buffer = tf2_ros.Buffer()
+        self.listener = tf2_ros.TransformListener(self.tf_buffer)
+
+        # These paramaters allow us to caluclate the angle per pixel in the image
+        # It could alternatively be done with camera_info topic
+        self.image_width = rospy.get_param("~image_width", 410)
+        self.field_of_view = rospy.get_param("~field_of_view", 1.05)
+
+        # How many times to rotate during search
+	self.rotation_limit = rospy.get_param("~rotation_limit", 8)
+
+        # How much to rotate during search (radians)
+        self.angle_increment = rospy.get_param("~angle_increment", 0.7)
+ 
+        # Waypoints
+        self.waypoints = []
+        waypoint_str = rospy.get_param("waypoints", "0 1 90, 0 0 0")
+        for wp_str in waypoint_str.split(","):
+            elems = wp_str.strip(" ").split()
+            self.waypoints.append(map(float, elems))
+
+        # Setup the service we serve
+        self.srv = rospy.Service("dock", Trigger, self.service_callback)
+ 
+        # Subscribe to fiducial messages 
+        self.fiducial_sub = rospy.Subscriber("/fiducial_vertices", 
+                                             FiducialArray, self.fiducial_callback)
+
+        # Create a proxy object for the move action server
+        self.move = actionlib.SimpleActionClient('/move_base',
+                                                 move_base_msgs.msg.MoveBaseAction)
+        rospy.loginfo("Waiting for move service to be available")
+        if not self.move.wait_for_server(rospy.Duration(10.0)):
+           rospy.logerr("Move service not available")
+           self.move = None
+           return
+        rospy.loginfo("Ready")
+        self.seen_fiducial = False
+
+        self.ok = True
+
+
+    def fiducial_callback(self, msg):
+        if len(msg.fiducials) > 0:
+            self.seen_fiducial = True
+
+    # This is called when we receive a rotate service call
+    def service_callback(self, req):
+        print("Received dock service call")
+
+        # Create a response to our service which we return later
+        response = TriggerResponse()
+
+        num_rotations = 0
+        self.seen_fiducial = False
+
+        # Rotate until we find the target
+        while not self.seen_fiducial and num_rotations < self.rotation_limit:
+            time.sleep(2)
+            if not self.seen_fiducial:
+                rospy.loginfo("Rotating to search for fiducial")
+                q = tf.transformations.quaternion_from_euler(0, 0,
+                        self.angle_increment)
+                if self.goto_goal(Quaternion(*q)):
+                    num_rotations += 1
+                else:
+                    response.message = "Error rotating"
+                    response.success = False
+                    return response
+            else:
+                rospy.loginfo("Not rotating because fiducial seen")
+
+        # Create a negative response to our rotate service call
+        if not self.seen_fiducial: 
+            response.message = "Not fiducial seen after rotating"
+            response.success = False
+            return response
+
+        # Go to each waypoint in succession
+        for x, y, theta in self.waypoints:
+            rospy.loginfo("Going to goal %f %f %f", x, y, theta)
+            q = tf.transformations.quaternion_from_euler(0, 0, radians(theta))
+            p = Point(x, y, 0)
+            if not self.goto_goal(Quaternion(*q), position=Point(x, y, 0), frame="map"):
+                 response.message = "Error going to goal %s %s %s" % (x, y, theta) 
+                 response.success = False
+                 return response
+
+        response.message = "Did it"
+        response.success = True
+        return response
+
+    # Go to a goal
+    def goto_goal(self, orientation, position=Point(), frame=None):
+        goal = move_base_msgs.msg.MoveBaseGoal()
+        if frame is None:
+            pose_base = PoseStamped()
+            pose_base.header.frame_id = "base_footprint"
+            pose_base.pose.orientation = orientation
+            pose_base.pose.position = position
+
+            try:
+                pose_odom = self.tf_buffer.transform(pose_base, "odom", rospy.Duration(1.0))
+            except:
+                rospy.logerr("Unable to transform goal into odom frame")
+                return False
+            goal.target_pose = pose_odom
+        else:
+            goal.target_pose = PoseStamped()
+            goal.target_pose.pose.orientation = orientation
+            goal.target_pose.pose.position = position
+            goal.target_pose.header.frame_id = frame
+        # Create goal and actionlib call to rotate
+        self.move.send_goal(goal)
+        self.move.wait_for_result(rospy.Duration(50.0))
+
+        return self.move.get_state() == GoalStatus.SUCCEEDED
+
+    # Just sleep while the node is running
+    def run(self):
+        rate = rospy.Rate(1)
+        while (not rospy.is_shutdown() and self.ok):
+            rate.sleep()
+        rospy.loginfo("Dock node exiting")
+
+if __name__ == "__main__":
+    # Create an instance of our Dock class
+    node = Dock()
+    # run it
+    node.run()

--- a/docking/nodes/dock.py
+++ b/docking/nodes/dock.py
@@ -78,7 +78,7 @@ class Dock:
  
         # Waypoints
         self.waypoints = []
-        waypoint_str = rospy.get_param("waypoints", "-1 0 0, 0 0 0")
+        waypoint_str = rospy.get_param("/docking/waypoints", "-1 0 0, 0 0 0")
         for wp_str in waypoint_str.split(","):
             elems = wp_str.strip(" ").split()
             self.waypoints.append(map(float, elems))

--- a/docking/nodes/dock.py
+++ b/docking/nodes/dock.py
@@ -78,7 +78,7 @@ class Dock:
  
         # Waypoints
         self.waypoints = []
-        waypoint_str = rospy.get_param("waypoints", "0 1 90, 0 0 0")
+        waypoint_str = rospy.get_param("waypoints", "-1 0 0, 0 0 0")
         for wp_str in waypoint_str.split(","):
             elems = wp_str.strip(" ").split()
             self.waypoints.append(map(float, elems))

--- a/docking/nodes/dock.py
+++ b/docking/nodes/dock.py
@@ -70,16 +70,11 @@ class Dock:
         self.tf_buffer = tf2_ros.Buffer()
         self.listener = tf2_ros.TransformListener(self.tf_buffer)
 
-        # These paramaters allow us to caluclate the angle per pixel in the image
-        # It could alternatively be done with camera_info topic
-        self.image_width = rospy.get_param("~image_width", 410)
-        self.field_of_view = rospy.get_param("~field_of_view", 1.05)
-
         # How many times to rotate during search
 	self.rotation_limit = rospy.get_param("~rotation_limit", 8)
 
-        # How much to rotate during search (radians)
-        self.angle_increment = rospy.get_param("~angle_increment", 0.7)
+        # How much to rotate during search (degrees)
+        self.angle_increment = radians(rospy.get_param("~angle_increment", 40))
  
         # Waypoints
         self.waypoints = []

--- a/docking/nodes/dock.py
+++ b/docking/nodes/dock.py
@@ -103,7 +103,7 @@ class Dock:
 
     def fiducial_callback(self, msg):
         for fiducial in msg.fiducials:
-            if fiducial.fiducial_id == target_fiducial:
+            if fiducial.fiducial_id == self.target_fiducial:
                 self.seen_fiducial = True
 
     # This is called when we receive a rotate service call

--- a/docking/package.xml
+++ b/docking/package.xml
@@ -5,7 +5,7 @@
   <description>The docking package</description>
 
   <maintainer email="jimv@mrjim.com">Jim Vaughan</maintainer>
-  <maintainer email="send2arohan@gmail.com">Rohan Agrawl</maintainer>
+  <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
 
   <license>BSD</license>
 

--- a/docking/package.xml
+++ b/docking/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <name>docking</name>
+  <version>0.0.0</version>
+  <description>The docking package</description>
+
+  <maintainer email="jimv@mrjim.com">Jim Vaughan</maintainer>
+  <maintainer email="send2arohan@gmail.com">Rohan Agrawl</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>fiducials</run_depend>
+  <run_depend>move_basic</run_depend>
+
+  <url type="website">https://github.com/UbiquityRobotics/demos</url>
+
+  <export>
+  </export>
+</package>

--- a/docking/srv/Dock.srv
+++ b/docking/srv/Dock.srv
@@ -1,0 +1,5 @@
+int32 fiducial_id
+string waypoints
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION

The docking node provides a dock service that can be invoked with a command like this:

```
rosservice call /dock "fiducial_id: 306
waypoints: '-1 Y 90,-.3 0 0 '" 
```

The robot will rotate until it either sees the target fiducial or completes one revolution.  If a fiducial is seen, it will attempt to navigate to the waypoints in sequence.  The format of a waypoint is three elements representing `x`, `y`, and `theta`. `x` and `y` are co-ordinates relative to the fiducial in meters and `theta is a heading angle in degrees.  The strings `X` and `Y` are replaced by the current `x` and `y` co-ordinates, respectively. 